### PR TITLE
Make data quality scope optional (#36)

### DIFF
--- a/src/main/resources/org/opengis/cite/trainingdmlai10part2/jsonschema/dataQuality.json
+++ b/src/main/resources/org/opengis/cite/trainingdmlai10part2/jsonschema/dataQuality.json
@@ -4,8 +4,7 @@
   "title": "DataQuality",
   "type": "object",
   "required": [
-    "type",
-    "scope"
+    "type"
   ],
   "properties": {
     "type": {


### PR DESCRIPTION
Fixes #36

This keeps scope as a supported DataQuality property, but no longer requires every quality element to repeat scope.