### PR TITLE
Allow data quality subtype names (#37)

### DIFF
--- a/src/main/resources/org/opengis/cite/trainingdmlai10part2/jsonschema/dataQuality.json
+++ b/src/main/resources/org/opengis/cite/trainingdmlai10part2/jsonschema/dataQuality.json
@@ -9,10 +9,7 @@
   ],
   "properties": {
     "type": {
-      "type": "string",
-      "enum": [
-        "DataQuality"
-      ]
+      "type": "string"
     },
     "scope": {
       "$ref": "md_scope.json"


### PR DESCRIPTION
Fixes #37

This relaxes the DataQuality type property so concrete quality element names such as AI_ClassBalanceDegree, FormatConsistency, and CompletenessCommission are accepted.