### PR TITLE
Accept array-form metricsInLIT values (#38)

### DIFF
--- a/src/main/java/org/opengis/cite/trainingdmlai10part2/aitrainingdataset/AITrainingDatasetTest.java
+++ b/src/main/java/org/opengis/cite/trainingdmlai10part2/aitrainingdataset/AITrainingDatasetTest.java
@@ -97,17 +97,18 @@ public class AITrainingDatasetTest extends CommonFixture {
             List<JsonNode> nodes = JsonUtils.findNodesByNames(rootNode, arrayToFetch);
 
             for (JsonNode targetNode : nodes) {
-                String nodeClass = targetNode.getClass().toString();
-                if (nodeClass.endsWith("com.fasterxml.jackson.databind.node.ObjectNode")) {
-                    Set<ValidationMessage> errors = schema.validate(targetNode);
-                    Iterator it = errors.iterator();
-                    while (it.hasNext()) {
-                        sb.append("Item " + targetNode + " has error " + it.next() + ".\n");
+                if (targetNode.isArray()) {
+                    for (JsonNode currentNode : targetNode) {
+                        validateMetricsInLiteratureNode(schema, currentNode, sb);
                     }
+                } else if (targetNode.isObject()) {
+                    validateMetricsInLiteratureNode(schema, targetNode, sb);
                 } else {
                     sb.append("Item " + targetNode + " is not an object.\n");
                 }
-            }
+            } 
+
+
 
         } catch (Exception e) {
             sb.append(e.getMessage());
@@ -148,5 +149,17 @@ public class AITrainingDatasetTest extends CommonFixture {
         }
 
         Assert.assertTrue(sb.toString().length() == 0, sb.toString());
+    }
+
+    private void validateMetricsInLiteratureNode(JsonSchema schema, JsonNode node, StringBuffer sb) {
+        if (!node.isObject()) {
+            sb.append("Item " + node + " is not an object.\n");
+            return;
+        }
+        Set<ValidationMessage> errors = schema.validate(node);
+        Iterator it = errors.iterator();
+        while (it.hasNext()) {
+            sb.append("Item " + node + " has error " + it.next() + ".\n");
+        }
     }
 }


### PR DESCRIPTION
Fixes #38

This updates verifyMetricsInLiterature to accept both a single metricsInLIT object and an array of metricsInLIT objects.